### PR TITLE
plic_regmap: Prevent latch inference

### DIFF
--- a/rtl/plic_regmap.sv
+++ b/rtl/plic_regmap.sv
@@ -32,6 +32,7 @@ always_comb begin
   ie_o = '0;
   ie_we_o = '0;
   ie_re_o = '0;
+  ip_re_o = '0;
   threshold_o = '0;
   threshold_we_o = '0;
   threshold_re_o = '0;


### PR DESCRIPTION
Solves the following Vivado 2018.2 warnings:

```
WARNING: [Synth 8-327] inferring latch for variable 'ip_re_o_reg' [ariane/src/rv_plic/rtl/plic_regmap.sv:98]
WARNING: [Synth 8-87] always_comb on 'ip_re_o_reg' did not result in combinational logic [ariane/src/rv_plic/rtl/plic_regmap.sv:98]
```