### PR TITLE
Upgrade register interface to v0.3.1

### DIFF
--- a/rtl/gen_plic_addrmap.py
+++ b/rtl/gen_plic_addrmap.py
@@ -64,7 +64,7 @@ class AddrMap:
     params =",\n".join(map(lambda x: "  " + x, [
       "parameter type reg_req_t  = logic",
       "parameter type reg_rsp_t  = logic"]))
-    output += "module {} {}(\n".format(self.name, f'#(\n{params}\n)')
+    output += "module {} {}(\n".format(self.name, "#(\n{}\n)".format(params))
     for i in self.ports:
       # self.ports.append((name, num, width, access))
       if i[3] == Access.RO:

--- a/rtl/gen_plic_addrmap.py
+++ b/rtl/gen_plic_addrmap.py
@@ -61,7 +61,10 @@ class AddrMap:
   """Dump Verilog"""
   def emit_verilog(self):
     output = "// Do not edit - auto-generated\n"
-    output += "module {} (\n".format(self.name)
+    params =",\n".join(map(lambda x: "  " + x, [
+      "parameter type reg_req_t  = logic",
+      "parameter type reg_rsp_t  = logic"]))
+    output += "module {} {}(\n".format(self.name, f'#(\n{params}\n)')
     for i in self.ports:
       # self.ports.append((name, num, width, access))
       if i[3] == Access.RO:
@@ -73,8 +76,8 @@ class AddrMap:
         output += "  output logic [{}:0] {}_we_o,\n".format(i[1]-1, i[0])
         output += "  output logic [{}:0] {}_re_o,\n".format(i[1]-1, i[0])
     output += "  // Bus Interface\n"
-    output += "  input  reg_intf::reg_intf_req_a32_d32 req_i,\n"
-    output += "  output reg_intf::reg_intf_resp_d32    resp_o\n"
+    output += "  input  reg_req_t req_i,\n"
+    output += "  output reg_rsp_t resp_o\n"
     output += ");\n"
     output += "always_comb begin\n"
     output += "  resp_o.ready = 1'b1;\n"

--- a/rtl/plic_regmap.sv
+++ b/rtl/plic_regmap.sv
@@ -2,7 +2,7 @@
 module plic_regs #(
   parameter type reg_req_t  = logic,
   parameter type reg_rsp_t  = logic
-) (
+)(
   input logic [30:0][2:0] prio_i,
   output logic [30:0][2:0] prio_o,
   output logic [30:0] prio_we_o,
@@ -35,7 +35,6 @@ always_comb begin
   ie_o = '0;
   ie_we_o = '0;
   ie_re_o = '0;
-  ip_re_o = '0;
   threshold_o = '0;
   threshold_we_o = '0;
   threshold_re_o = '0;
@@ -355,3 +354,4 @@ always_comb begin
   end
 end
 endmodule
+

--- a/rtl/plic_regmap.sv
+++ b/rtl/plic_regmap.sv
@@ -1,5 +1,8 @@
 // Do not edit - auto-generated
-module plic_regs (
+module plic_regs #(
+  parameter type reg_req_t  = logic,
+  parameter type reg_rsp_t  = logic
+) (
   input logic [30:0][2:0] prio_i,
   output logic [30:0][2:0] prio_o,
   output logic [30:0] prio_we_o,
@@ -19,8 +22,8 @@ module plic_regs (
   output logic [1:0] cc_we_o,
   output logic [1:0] cc_re_o,
   // Bus Interface
-  input  reg_intf::reg_intf_req_a32_d32 req_i,
-  output reg_intf::reg_intf_resp_d32    resp_o
+  input  reg_req_t req_i,
+  output reg_rsp_t resp_o
 );
 always_comb begin
   resp_o.ready = 1'b1;

--- a/rtl/plic_top.sv
+++ b/rtl/plic_top.sv
@@ -9,10 +9,8 @@
 // specific language governing permissions and limitations under the License.
 //
 // Author:  Florian Zaruba <zaruabf@iis.ee.ethz.ch>
-//          Andreas Kuster, <kustera@ethz.ch>
 //
 // Description: Platform level interrupt controller
-
 
 module plic_top #(
   parameter int N_SOURCE    = 30,

--- a/rtl/plic_top.sv
+++ b/rtl/plic_top.sv
@@ -1,14 +1,32 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author:  Florian Zaruba <zaruabf@iis.ee.ethz.ch>
+//          Andreas Kuster, <kustera@ethz.ch>
+//
+// Description: Platform level interrupt controller
+
+
 module plic_top #(
   parameter int N_SOURCE    = 30,
   parameter int N_TARGET    = 2,
   parameter int MAX_PRIO    = 7,
-  parameter int SRCW        = $clog2(N_SOURCE+1)
+  parameter int SRCW        = $clog2(N_SOURCE+1),
+  parameter type reg_req_t  = logic,
+  parameter type reg_rsp_t  = logic
 ) (
   input  logic clk_i,    // Clock
   input  logic rst_ni,  // Asynchronous reset active low
   // Bus Interface
-  input  reg_intf::reg_intf_req_a32_d32 req_i,
-  output reg_intf::reg_intf_resp_d32    resp_o,
+  input  reg_req_t req_i,
+  output reg_rsp_t resp_o,
   input logic [N_SOURCE-1:0] le_i, // 0:level 1:edge
   // Interrupt Sources
   input  logic [N_SOURCE-1:0] irq_sources_i,
@@ -83,7 +101,10 @@ module plic_top #(
   logic [N_TARGET-1:0][N_SOURCE:0] ie_i, ie_o;
   logic [N_TARGET-1:0] ie_we_o;
 
-  plic_regs i_plic_regs (
+  plic_regs #(
+    .reg_req_t ( reg_req_t ),
+    .reg_rsp_t ( reg_rsp_t )
+  ) i_plic_regs (
     .prio_i(prio_i),
     .prio_o(prio_o),
     .prio_we_o(prio_we_o),


### PR DESCRIPTION
This upgrade is in conjunction with https://github.com/openhwgroup/cva6/pull/819 (i.e. cva6 `register_interface` upgrade)